### PR TITLE
Update api.py

### DIFF
--- a/whitelabel/api.py
+++ b/whitelabel/api.py
@@ -20,7 +20,7 @@ def update_field_label():
 	frappe.db.sql("""Update `tabDocField` set label='ERP' where fieldname='erpnext_user' and parent='Employee'""")
 
 def get_frappe_version():
-	return frappe.db.get_value("Installed Application",{"app_name":"frappe"},"app_version").split('.')[0]
+	return 13
 
 def update_onboard_details():
 	update_onboard_module()


### PR DESCRIPTION
The frappecloud already checks for version and only allows specific compatible versions to be implemented, the check for version does no longer work and that's why I created this PR to hardcode it for now and later we can remove it entirely and adhere to standards set by frappe.

Currently fixes the issue since the query doesn't work on the latest version. 
- Temporary fix
